### PR TITLE
use project environment variables

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -213,10 +213,10 @@ class PrefectCloudIntegration:
         job_suffix = self._hash_flow(flow)[0:12]
         job_name = f"{job_name}-{job_suffix}"
         host_aliases = saturn_details["host_aliases"]
-        job_env = {
-            "BASE_URL": self._base_url,
-            "SATURN_TOKEN": saturn_details["deployment_token"],
-        }
+        job_env = saturn_details["environment_variables"]
+        job_env.update(
+            {"BASE_URL": self._base_url, "SATURN_TOKEN": saturn_details["deployment_token"]}
+        )
 
         # fill out template for the jobs that handle flow runs
         template_content = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,7 +21,7 @@ SATURN_DETAILS_RESPONSE = {
     "host_aliases": [],
     "deployment_token": TEST_DEPLOYMENT_TOKEN,
     "image_name": TEST_IMAGE,
-    "environment_variables": {}
+    "environment_variables": {},
 }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -150,6 +150,7 @@ def test_get_saturn_details():
             "host_aliases": [],
             "deployment_token": test_token,
             "image_name": test_image,
+            "environment_variables": {},
         },
     )
     saturn_details = integration.saturn_details
@@ -158,6 +159,7 @@ def test_get_saturn_details():
     assert integration._saturn_details["deployment_token"] == test_token
     assert integration._saturn_details["image_name"] == test_image
     assert integration._saturn_details["registry_url"] == test_registry
+    assert integration._saturn_details["environment_variables"] == {}
 
 
 @responses.activate


### PR DESCRIPTION

- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR changes the strategy for creating a `KubernetesJobEnvironment`. It makes use of Saturn environment variables (see ["Customizing Saturn Projects"](https://docs.saturncloud.io/en/articles/4124983-customizing-saturn-projects)).

## How does this PR improve `prefect-saturn`?

This allows for more control over the environment where a Prefect flow is run, and allows users to re-use environment variables that they've already set up in their Saturn projects.

It also reduces a source of inconsistency between the job where a flow is run and the worker nodes in the Dask cluster its tasks execute on.