### PR TITLE
add more thorough tests

### DIFF
--- a/prefect_saturn/__init__.py
+++ b/prefect_saturn/__init__.py
@@ -3,3 +3,4 @@ imports added so users do not have to think about submodules
 """
 
 from .core import PrefectCloudIntegration  # noqa: F401
+from .messages import Errors  # noqa: F401

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -8,6 +8,7 @@ import os
 from typing import Any, Dict, Optional
 from requests import Session
 from requests.adapters import HTTPAdapter
+from requests.models import Response
 from requests.packages.urllib3.util.retry import Retry
 
 
@@ -183,7 +184,7 @@ class PrefectCloudIntegration:
         )
         return flow
 
-    def build_storage(self, flow: Flow):
+    def build_storage(self, flow: Flow) -> Response:
         """
         Actually build and push the storage
         """

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -239,6 +239,7 @@ class PrefectCloudIntegration:
                                 "env": [{"name": k, "value": v} for k, v in job_env.items()],
                             }
                         ],
+                        "nodeSelector": saturn_details["node_selector"],
                     },
                 }
             },

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,6 +90,8 @@ def REGISTER_FLOW_FAILURE_RESPONSE(status: int):
 # -------------------------------------------- #
 # /api/prefect_cloud/flows/{id}/saturn_details #
 # -------------------------------------------- #
+TEST_NODE_ROLE_KEY = "some-stuff/role"
+TEST_NODE_ROLE = "medium"
 SATURN_DETAILS_RESPONSE = {
     "method": responses.GET,
     "url": f"{os.environ['BASE_URL']}/api/prefect_cloud/flows/{TEST_FLOW_ID}/saturn_details",
@@ -99,6 +101,7 @@ SATURN_DETAILS_RESPONSE = {
         "deployment_token": TEST_DEPLOYMENT_TOKEN,
         "image_name": TEST_IMAGE,
         "environment_variables": {},
+        "node_selector": {TEST_NODE_ROLE_KEY: TEST_NODE_ROLE},
     },
     "status": 200,
 }
@@ -259,6 +262,7 @@ def test_get_saturn_details():
     assert integration._saturn_details["image_name"] == TEST_IMAGE
     assert integration._saturn_details["registry_url"] == test_registry
     assert integration._saturn_details["environment_variables"] == {}
+    assert integration._saturn_details["node_selector"] == {TEST_NODE_ROLE_KEY: TEST_NODE_ROLE}
 
 
 @responses.activate


### PR DESCRIPTION

- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?
the libr
This PR refactors the unit tests so that there is less repetition of the stuff needed to mock requests with `responses`. It also lot more tests, covering some parts of the code that were previously uncovered.

## How does this PR improve `prefect-saturn`?

This PR should improve our release confidence by thoroughly covering the behavior of `prefect-saturn`. As of this PR, the library must be 100% covered by unit tests for builds to pass.