### PR TITLE
Add project secrets

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -218,6 +218,7 @@ class PrefectCloudIntegration:
         job_env.update(
             {"BASE_URL": self._base_url, "SATURN_TOKEN": saturn_details["deployment_token"]}
         )
+        env_vars_secret_name = saturn_details["env_vars_secret_name"]
 
         # fill out template for the jobs that handle flow runs
         template_content = {
@@ -237,6 +238,7 @@ class PrefectCloudIntegration:
                                 "command": [],
                                 "args": [],
                                 "env": [{"name": k, "value": v} for k, v in job_env.items()],
+                                "envFrom": [{"secretRef": {"name": env_vars_secret_name}}],
                             }
                         ],
                         "nodeSelector": saturn_details["node_selector"],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,6 +92,7 @@ def REGISTER_FLOW_FAILURE_RESPONSE(status: int):
 # -------------------------------------------- #
 TEST_NODE_ROLE_KEY = "some-stuff/role"
 TEST_NODE_ROLE = "medium"
+TEST_ENV_SECRET_NAME = "prefect-some-n0ns3nse"
 SATURN_DETAILS_RESPONSE = {
     "method": responses.GET,
     "url": f"{os.environ['BASE_URL']}/api/prefect_cloud/flows/{TEST_FLOW_ID}/saturn_details",
@@ -102,6 +103,7 @@ SATURN_DETAILS_RESPONSE = {
         "image_name": TEST_IMAGE,
         "environment_variables": {},
         "node_selector": {TEST_NODE_ROLE_KEY: TEST_NODE_ROLE},
+        "env_vars_secret_name": TEST_ENV_SECRET_NAME,
     },
     "status": 200,
 }
@@ -263,6 +265,7 @@ def test_get_saturn_details():
     assert integration._saturn_details["registry_url"] == test_registry
     assert integration._saturn_details["environment_variables"] == {}
     assert integration._saturn_details["node_selector"] == {TEST_NODE_ROLE_KEY: TEST_NODE_ROLE}
+    assert integration._saturn_details["env_vars_secret_name"] == TEST_ENV_SECRET_NAME
 
 
 @responses.activate


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-saturn! -->

<!--
    Please check a few things before pushing.

    Running `make format` will help your code pass
    `make lint`.
-->

- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR adds a secret to the the job spec YAML used by `KubernetesJobEnvironment`.

## How does this PR improve `prefect-saturn`?

As of this change (and corresponding changes in the Saturn backend), Saturn project environment variables will be accessible to the job that runs `flow.run()` when Prefect Cloud kicks off a new flow run.

See ["Customizing Saturn Projects"](https://docs.saturncloud.io/en/articles/4124983-customizing-saturn-projects) for details on using environment variables in Saturn projects.

## Notes for reviewers

This was branched off of #2 . The diff will get much smaller when we merge that PR, and that one should be merged first.
