### PR TITLE
Add more metadata to flows

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -255,8 +255,8 @@ class PrefectCloudIntegration:
         flow.environment = KubernetesJobEnvironment(
             metadata={
                 "saturn_flow_id": self._saturn_flow_id,
-                "saturn_commit_hash": self.saturn_details["saturn_commit_hash"]
-            }
+                "saturn_commit_hash": self.saturn_details["saturn_commit_hash"],
+            },
             executor=DaskExecutor(
                 cluster_class="dask_saturn.SaturnCluster",
                 cluster_kwargs=cluster_kwargs,

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -251,9 +251,7 @@ class PrefectCloudIntegration:
             f.write(yaml.dump(template_content))
 
         flow.environment = KubernetesJobEnvironment(
-            metadata={
-                "saturn_flow_id": self._saturn_flow_id,
-            },
+            metadata={"saturn_flow_id": self._saturn_flow_id,},
             executor=DaskExecutor(
                 cluster_class="dask_saturn.SaturnCluster",
                 cluster_kwargs=cluster_kwargs,

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -251,11 +251,9 @@ class PrefectCloudIntegration:
         with open(local_tmp_file, "w") as f:
             f.write(yaml.dump(template_content))
 
-        # TODO: add flow_id to "metadata" so the agent can use it
         flow.environment = KubernetesJobEnvironment(
             metadata={
                 "saturn_flow_id": self._saturn_flow_id,
-                "saturn_commit_hash": self.saturn_details["saturn_commit_hash"],
             },
             executor=DaskExecutor(
                 cluster_class="dask_saturn.SaturnCluster",

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -251,7 +251,7 @@ class PrefectCloudIntegration:
             f.write(yaml.dump(template_content))
 
         flow.environment = KubernetesJobEnvironment(
-            metadata={"saturn_flow_id": self._saturn_flow_id,},
+            metadata={"saturn_flow_id": self._saturn_flow_id},
             executor=DaskExecutor(
                 cluster_class="dask_saturn.SaturnCluster",
                 cluster_kwargs=cluster_kwargs,

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -251,7 +251,12 @@ class PrefectCloudIntegration:
         with open(local_tmp_file, "w") as f:
             f.write(yaml.dump(template_content))
 
+        # TODO: add flow_id to "metadata" so the agent can use it
         flow.environment = KubernetesJobEnvironment(
+            metadata={
+                "saturn_flow_id": self._saturn_flow_id,
+                "saturn_commit_hash": self.saturn_details["saturn_commit_hash"]
+            }
             executor=DaskExecutor(
                 cluster_class="dask_saturn.SaturnCluster",
                 cluster_kwargs=cluster_kwargs,

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -178,7 +178,6 @@ class PrefectCloudIntegration:
             image_name=saturn_details["image_name"],
             image_tag=image_tag,
             registry_url=saturn_details["registry_url"],
-            python_dependencies=["git+https://github.com/saturncloud/dask-saturn@main"],
             prefect_directory="/tmp",
             env_vars={"SATURN_TOKEN": "placeholder-token", "BASE_URL": "placeholder-url"},
         )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -156,13 +156,13 @@ def test_initialize_raises_error_on_failure():
 
 def test_initialize_raises_error_on_missing_saturn_token(monkeypatch):
     monkeypatch.delenv("SATURN_TOKEN")
-    with raises(RuntimeError, match=prefect_saturn.Errors.missing_env_var("SATURN_TOKEN")):
+    with raises(RuntimeError, match="environment variable SATURN_TOKEN not found"):
         prefect_saturn.PrefectCloudIntegration(prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME)
 
 
 def test_initialize_raises_error_on_missing_base_url(monkeypatch):
     monkeypatch.delenv("BASE_URL")
-    with raises(RuntimeError, match=prefect_saturn.Errors.missing_env_var("BASE_URL")):
+    with raises(RuntimeError, match="environment variable BASE_URL not found"):
         prefect_saturn.PrefectCloudIntegration(prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -156,7 +156,7 @@ def test_initialize_raises_error_on_failure():
 
 def test_initialize_raises_error_on_missing_saturn_token(monkeypatch):
     monkeypatch.delenv("SATURN_TOKEN")
-    with raises(RuntimeError, match=prefect_saturn.Errors.missing_env_var("SATURN_TOKEN"))::
+    with raises(RuntimeError, match=prefect_saturn.Errors.missing_env_var("SATURN_TOKEN")):
         prefect_saturn.PrefectCloudIntegration(prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -156,13 +156,13 @@ def test_initialize_raises_error_on_failure():
 
 def test_initialize_raises_error_on_missing_saturn_token(monkeypatch):
     monkeypatch.delenv("SATURN_TOKEN")
-    with raises(RuntimeError, match="environment variable SATURN_TOKEN not found"):
+    with raises(RuntimeError, match=prefect_saturn.Errors.missing_env_var("SATURN_TOKEN"))::
         prefect_saturn.PrefectCloudIntegration(prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME)
 
 
 def test_initialize_raises_error_on_missing_base_url(monkeypatch):
     monkeypatch.delenv("BASE_URL")
-    with raises(RuntimeError, match="environment variable BASE_URL not found"):
+    with raises(RuntimeError, match=prefect_saturn.Errors.missing_env_var("BASE_URL")):
         prefect_saturn.PrefectCloudIntegration(prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME)
 
 


### PR DESCRIPTION
This PR includes a few updates that improve execution and testing for the end-to-end experience with Prefect Cloud.

## What does this PR change?

This PR adds more details from Saturn to the flow, so the agent running it knows how to configure the first job that loads the flow.

## How does this PR improve `prefect-saturn`?

This PR allows flows executed from Prefect Cloud to take advantage of Saturn-y customization features like env secrets, filesystem secrets, and a custom start script.
