### PR TITLE
add custom label for flows

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -40,7 +40,7 @@ class PrefectCloudIntegration:
             project_name=PROJECT_NAME,
             build=False,
             labels=[
-                "s3-flow-storage"
+                "saturn-cloud"
             ]
         )
     """


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR updates the documentation to show that users should use label `saturn-cloud` on their flows to get them to run on a Saturn agent.

## How does this PR improve `prefect-saturn`?

This PR keeps the documentation up to date with the current state of saturn.
