### PR TITLE
change strategy for identifying flows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,7 @@ jobs:
         if: matrix.task == 'unit-tests'
         shell: bash
         run: |
-          pip install cloudpickle==1.4.1
-          pip install --upgrade pytest pytest-cov responses
+          pip install --upgrade cloudpickle pytest pytest-cov responses
           make unit-tests
       - name: todo-checks
         if: matrix.task == 'todo-checks'

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -4,6 +4,7 @@ This module contains the user-facing API for ``prefect-saturn``.
 
 import hashlib
 import os
+import uuid
 
 from typing import Any, Dict, Optional
 from requests import Session
@@ -168,11 +169,14 @@ class PrefectCloudIntegration:
 
     def add_storage(self, flow: Flow) -> Flow:
         """
-        Get a Docker Storage object with Saturn-y
-        details.
+        Create a Docker Storage object with Saturn-y details and set
+        it on `flow.storage`.
+
+        This method sets the `image_tag` to a random string to avoid conflicts.
+        The image name is generated in Saturn.
         """
         saturn_details = self.saturn_details
-        image_tag = self._hash_flow(flow)[0:12]
+        image_tag = str(uuid.uuid4())
         # NOTE: SATURN_TOKEN and BASE_URL have to be set to be able
         #       to load the flow. Those variables will be overridden by
         #       Kubernetes in all the places where it matters, and values

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -214,9 +214,11 @@ class PrefectCloudIntegration:
         cluster_kwargs = cluster_kwargs or {"n_workers": 1}
         adapt_kwargs = adapt_kwargs or {"minimum": 1, "maximum": 2}
         saturn_details = self.saturn_details
-        job_name = f"pfct-{flow.name}"
-        job_suffix = self._hash_flow(flow)[0:12]
-        job_name = f"{job_name}-{job_suffix}"
+
+        # setting unique_job_name=True on the environment is enough to guarantee
+        # uniqueness for this job name
+        flow_hash = self._hash_flow(flow)
+        job_name = f"pct-{flow_hash}"
         host_aliases = saturn_details["host_aliases"]
         job_env = saturn_details["environment_variables"]
         job_env.update(
@@ -263,5 +265,6 @@ class PrefectCloudIntegration:
                 adapt_kwargs=adapt_kwargs,
             ),
             job_spec_file=local_tmp_file,
+            unique_job_name=True,
         )
         return flow

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -347,6 +347,7 @@ def test_build_environment():
         flow = integration.add_environment(flow=flow)
         assert isinstance(flow.environment, KubernetesJobEnvironment)
         assert isinstance(flow.environment.executor, DaskExecutor)
+        assert flow.environment.unique_job_name is True
 
 
 @responses.activate

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,7 @@ from prefect.environments import KubernetesJobEnvironment
 from prefect.environments.storage import Docker
 from pytest import raises
 from requests.exceptions import HTTPError
+from unittest.mock import patch
 
 os.environ["SATURN_TOKEN"] = "placeholder-token"
 os.environ["BASE_URL"] = "http://placeholder-url"
@@ -124,6 +125,12 @@ BUILD_STORAGE_RESPONSE = {
 }
 
 
+class MockClient:
+    def __init__(self):
+        self._active_tenant_id = "543c5453-0a47-496a-9c61-a6765acef352"
+        pass
+
+
 @responses.activate
 def test_initialize():
     responses.add(**CURRENT_IMAGE_RESPONSE)
@@ -176,195 +183,241 @@ def test_hash_flow():
         prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
     )
 
-    flow_hash = integration._hash_flow(flow)
-    assert isinstance(flow_hash, str) and len(flow_hash) > 0
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        flow_hash = integration._hash_flow(flow)
+        assert isinstance(flow_hash, str) and len(flow_hash) > 0
 
-    # should be deterministic
-    flow_hash_again = integration._hash_flow(flow)
-    assert flow_hash == flow_hash_again
+        # should be deterministic
+        flow_hash_again = integration._hash_flow(flow)
+        assert flow_hash == flow_hash_again
 
-    # should not be impacted by storage
-    flow.storage = Docker()
-    assert flow_hash == integration._hash_flow(flow)
+        # should not be impacted by storage
+        flow.storage = Docker()
+        assert flow_hash == integration._hash_flow(flow)
 
-    # should not be impacted by environment
-    flow.environment = KubernetesJobEnvironment()
-    assert flow_hash == integration._hash_flow(flow)
+        # should not be impacted by environment
+        flow.environment = KubernetesJobEnvironment()
+        assert flow_hash == integration._hash_flow(flow)
 
-    # should change if you add a new task
-    @task
-    def goodbye_task():
-        logger = prefect.context.get("logger")
-        logger.info("adios")
+        # should not change if you add a new task
+        @task
+        def goodbye_task():
+            logger = prefect.context.get("logger")
+            logger.info("adios")
 
-    flow.tasks = [hello_task, goodbye_task]
-    new_flow_hash = integration._hash_flow(flow)
+        flow.tasks = [hello_task, goodbye_task]
+        new_flow_hash = integration._hash_flow(flow)
 
-    assert isinstance(new_flow_hash, str) and len(new_flow_hash) > 0
-    assert new_flow_hash != flow_hash
+        assert isinstance(new_flow_hash, str) and len(new_flow_hash) > 0
+        assert new_flow_hash == flow_hash
+
+        # should change if flow name changes
+        flow.name = str(uuid.uuid4())
+        new_flow_hash = integration._hash_flow(flow)
+        assert new_flow_hash != flow_hash
+
+        # should change if project name changes
+        previous_flow_hash = new_flow_hash
+        integration.prefect_cloud_project_name = str(uuid.uuid4())
+        new_flow_hash = integration._hash_flow(flow)
+        assert isinstance(new_flow_hash, str) and len(new_flow_hash) > 0
+        assert new_flow_hash != previous_flow_hash
+
+
+@responses.activate
+def test_hash_flow_hash_changes_if_tenant_id_changes():
+    responses.add(**CURRENT_IMAGE_RESPONSE)
+
+    flow = TEST_FLOW.copy()
+
+    integration = prefect_saturn.PrefectCloudIntegration(
+        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+    )
+
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        flow_hash = integration._hash_flow(flow)
+        assert isinstance(flow_hash, str) and len(flow_hash) > 0
+
+    class OtherMockClient:
+        def __init__(self):
+            self._active_tenant_id = "some-other-garbage"
+
+    with patch("prefect_saturn.core.Client", new=OtherMockClient):
+        new_flow_hash = integration._hash_flow(flow)
+        assert isinstance(new_flow_hash, str) and len(new_flow_hash) > 0
+        assert new_flow_hash != flow_hash
 
 
 @responses.activate
 def test_register_flow_with_saturn():
-    test_flow_id = random.randint(1, 500)
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    responses.add(**REGISTER_FLOW_RESPONSE(flow_id=test_flow_id))
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        test_flow_id = random.randint(1, 500)
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        responses.add(**REGISTER_FLOW_RESPONSE(flow_id=test_flow_id))
 
-    # Set up integration
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
+        # Set up integration
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
 
-    assert integration._saturn_flow_id is None
-    integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
-    assert integration._saturn_flow_id == test_flow_id
+        assert integration._saturn_flow_id is None
+        integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
+        assert integration._saturn_flow_id == test_flow_id
 
 
 @responses.activate
 def test_register_flow_with_saturn_raises_error_on_failure():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
 
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
 
-    responses.add(**REGISTER_FLOW_FAILURE_RESPONSE(500))
-    with raises(HTTPError, match="500 Server Error"):
-        integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
+        responses.add(**REGISTER_FLOW_FAILURE_RESPONSE(500))
+        with raises(HTTPError, match="500 Server Error"):
+            integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
 
-    failure_response = REGISTER_FLOW_FAILURE_RESPONSE(401)
-    failure_response["method_or_response"] = failure_response.pop("method")
-    responses.replace(**failure_response)
-    with raises(HTTPError, match="401 Client Error"):
-        integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
+        failure_response = REGISTER_FLOW_FAILURE_RESPONSE(401)
+        failure_response["method_or_response"] = failure_response.pop("method")
+        responses.replace(**failure_response)
+        with raises(HTTPError, match="401 Client Error"):
+            integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
 
 
 @responses.activate
 def test_get_saturn_details():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    responses.add(**REGISTER_FLOW_RESPONSE())
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        responses.add(**REGISTER_FLOW_RESPONSE())
 
-    test_token = str(uuid.uuid4())
-    test_registry = "8987.ecr.aws"
-    details = deepcopy(SATURN_DETAILS_RESPONSE)
-    details["json"].update({"registry_url": test_registry, "deployment_token": test_token})
-    responses.add(**details)
+        test_token = str(uuid.uuid4())
+        test_registry = "8987.ecr.aws"
+        details = deepcopy(SATURN_DETAILS_RESPONSE)
+        details["json"].update({"registry_url": test_registry, "deployment_token": test_token})
+        responses.add(**details)
 
-    # Set up integration
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
-    integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
+        # Set up integration
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
+        integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
 
-    # response with details for building storage
-    saturn_details = integration.saturn_details
-    assert isinstance(saturn_details, dict)
-    assert integration._saturn_details["host_aliases"] == []
-    assert integration._saturn_details["deployment_token"] == test_token
-    assert integration._saturn_details["image_name"] == TEST_IMAGE
-    assert integration._saturn_details["registry_url"] == test_registry
-    assert integration._saturn_details["environment_variables"] == {}
-    assert integration._saturn_details["node_selector"] == {TEST_NODE_ROLE_KEY: TEST_NODE_ROLE}
-    assert integration._saturn_details["env_vars_secret_name"] == TEST_ENV_SECRET_NAME
+        # response with details for building storage
+        saturn_details = integration.saturn_details
+        assert isinstance(saturn_details, dict)
+        assert integration._saturn_details["host_aliases"] == []
+        assert integration._saturn_details["deployment_token"] == test_token
+        assert integration._saturn_details["image_name"] == TEST_IMAGE
+        assert integration._saturn_details["registry_url"] == test_registry
+        assert integration._saturn_details["environment_variables"] == {}
+        assert integration._saturn_details["node_selector"] == {TEST_NODE_ROLE_KEY: TEST_NODE_ROLE}
+        assert integration._saturn_details["env_vars_secret_name"] == TEST_ENV_SECRET_NAME
 
 
 @responses.activate
 def test_get_saturn_details_raises_error_on_failure():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    responses.add(**REGISTER_FLOW_RESPONSE())
-    responses.add(**SATURN_DETAILS_FAILURE_RESPONSE)
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        responses.add(**REGISTER_FLOW_RESPONSE())
+        responses.add(**SATURN_DETAILS_FAILURE_RESPONSE)
 
-    # Set up integration
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
-    integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
-    with raises(HTTPError, match="404 Client Error"):
-        integration.saturn_details
+        # Set up integration
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
+        integration.register_flow_with_saturn(flow=TEST_FLOW.copy())
+        with raises(HTTPError, match="404 Client Error"):
+            integration.saturn_details
 
 
 @responses.activate
 def test_build_environment():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    responses.add(**REGISTER_FLOW_RESPONSE())
-    responses.add(**SATURN_DETAILS_RESPONSE)
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        responses.add(**REGISTER_FLOW_RESPONSE())
+        responses.add(**SATURN_DETAILS_RESPONSE)
 
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
-    flow = TEST_FLOW.copy()
-    integration.register_flow_with_saturn(flow=flow)
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
+        flow = TEST_FLOW.copy()
+        integration.register_flow_with_saturn(flow=flow)
 
-    flow = integration.add_environment(flow=flow)
-    assert isinstance(flow.environment, KubernetesJobEnvironment)
-    assert isinstance(flow.environment.executor, DaskExecutor)
+        flow = integration.add_environment(flow=flow)
+        assert isinstance(flow.environment, KubernetesJobEnvironment)
+        assert isinstance(flow.environment.executor, DaskExecutor)
 
 
 @responses.activate
 def test_add_storage():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    responses.add(**REGISTER_FLOW_RESPONSE())
-    responses.add(**SATURN_DETAILS_RESPONSE)
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        responses.add(**REGISTER_FLOW_RESPONSE())
+        responses.add(**SATURN_DETAILS_RESPONSE)
 
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
-    flow = TEST_FLOW.copy()
-    integration.register_flow_with_saturn(flow=flow)
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
+        flow = TEST_FLOW.copy()
+        integration.register_flow_with_saturn(flow=flow)
 
-    assert flow.storage is None
-    flow = integration.add_storage(flow=flow)
-    assert isinstance(flow.storage, Docker)
-    assert flow.storage.base_image == TEST_IMAGE
-    assert flow.storage.image_name == integration.saturn_details["image_name"]
-    assert flow.storage.registry_url == TEST_REGISTRY_URL
-    assert flow.storage.prefect_directory == "/tmp"
-    assert "BASE_URL" in flow.storage.env_vars.keys()
-    assert "SATURN_TOKEN" in flow.storage.env_vars.keys()
+        assert flow.storage is None
+        flow = integration.add_storage(flow=flow)
+        assert isinstance(flow.storage, Docker)
+        assert flow.storage.base_image == TEST_IMAGE
+        assert flow.storage.image_name == integration.saturn_details["image_name"]
+        assert flow.storage.registry_url == TEST_REGISTRY_URL
+        assert flow.storage.prefect_directory == "/tmp"
+        assert "BASE_URL" in flow.storage.env_vars.keys()
+        assert "SATURN_TOKEN" in flow.storage.env_vars.keys()
 
 
 @responses.activate
 def test_add_storage_fails_if_flow_not_registerd():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
-    flow = TEST_FLOW.copy()
-    with raises(RuntimeError, match=prefect_saturn.Errors.NOT_REGISTERED):
-        integration.add_storage(flow=flow)
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
+        flow = TEST_FLOW.copy()
+        with raises(RuntimeError, match=prefect_saturn.Errors.NOT_REGISTERED):
+            integration.add_storage(flow=flow)
 
 
 @responses.activate
 def test_build_storage():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    responses.add(**REGISTER_FLOW_RESPONSE())
-    responses.add(**SATURN_DETAILS_RESPONSE)
-    responses.add(**BUILD_STORAGE_RESPONSE)
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        responses.add(**REGISTER_FLOW_RESPONSE())
+        responses.add(**SATURN_DETAILS_RESPONSE)
+        responses.add(**BUILD_STORAGE_RESPONSE)
 
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
-    flow = TEST_FLOW.copy()
-    integration.register_flow_with_saturn(flow=flow)
-    flow = integration.add_storage(flow=flow)
-    res = integration.build_storage(flow)
-    assert res.status_code == 201
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
+        flow = TEST_FLOW.copy()
+        integration.register_flow_with_saturn(flow=flow)
+        flow = integration.add_storage(flow=flow)
+        res = integration.build_storage(flow)
+        assert res.status_code == 201
 
 
 @responses.activate
 def test_build_storage_fails_if_flow_not_registered():
-    responses.add(**CURRENT_IMAGE_RESPONSE)
-    responses.add(**REGISTER_FLOW_RESPONSE())
-    responses.add(**SATURN_DETAILS_RESPONSE)
-    responses.add(**BUILD_STORAGE_RESPONSE)
+    with patch("prefect_saturn.core.Client", new=MockClient):
+        responses.add(**CURRENT_IMAGE_RESPONSE)
+        responses.add(**REGISTER_FLOW_RESPONSE())
+        responses.add(**SATURN_DETAILS_RESPONSE)
+        responses.add(**BUILD_STORAGE_RESPONSE)
 
-    integration = prefect_saturn.PrefectCloudIntegration(
-        prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
-    )
-    flow = TEST_FLOW.copy()
-    integration.register_flow_with_saturn(flow=flow)
-    flow = integration.add_storage(flow=flow)
+        integration = prefect_saturn.PrefectCloudIntegration(
+            prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
+        )
+        flow = TEST_FLOW.copy()
+        integration.register_flow_with_saturn(flow=flow)
+        flow = integration.add_storage(flow=flow)
 
-    integration._saturn_flow_id = None
-    with raises(RuntimeError, match=prefect_saturn.Errors.NOT_REGISTERED):
-        integration.build_storage(flow)
+        integration._saturn_flow_id = None
+        with raises(RuntimeError, match=prefect_saturn.Errors.NOT_REGISTERED):
+            integration.build_storage(flow)


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR changes the strategy for uniquely identifying flows. Now the `flow_hash` sent to Saturn Cloud is the sha256 hash of:

* project name
* flow name
* Prefect Cloud tenant id

This means that `flow_hash` is equivalent to the Prefect Cloud concept `flow_group_id`. This PR proposes creating this hash ourselves because Prefect Cloud's `flow_group_id` can't be known until you've registered a flow with Prefect Cloud, and `prefect-saturn` needs to register with Saturn first.

## How does this PR improve `prefect-saturn`?

This PR provides a reliable way to uniquely identify all versions of the same flow. It improves on the previous model, where tenant id was not considered. The previous model could have caused conflicts in the case where two flows with identical names and code, in Prefect Cloud projects with the same name but in different tenants, would get the same hash and conflict.

Because this PR no longer considers the task graph in the hash, it also means that the hash will not change as a flow's task graph changes. That means pushing `Docker` storage to a container registry should be a lot faster, since it'll be more likely to hit the registry's cache.

## Notes for Reviewers

I had to introduce `prefect.client.Client` in this PR, and then mock it with `patch()`. A lot of the diff in the test files is just whitespace, the result of adding in a `with patch(....)`. I recommend reviewing with whitespace changes hidden.