### PR TITLE
add job to publish releases to PyPi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,36 @@
+name: Publish prefect-saturn to PyPI
+on:
+  release:
+    types:
+      - published
+jobs:
+  build-and-publish:
+    name: Build and publish prefect-saturn to PyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install build dependencies
+      run: >-
+        python -m
+        pip install
+        setuptools
+        wheel
+        --upgrade
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python
+        setup.py
+        sdist
+        bdist_wheel
+    - name: Publish distribution to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.3.1
+      with:
+        # Password is set in GitHub UI to an API secret for pypi
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -28,7 +28,6 @@ jobs:
         sdist
         bdist_wheel
     - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.3.1
       with:
         # Password is set in GitHub UI to an API secret for pypi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ This document contains details on contributing to `prefect-saturn`.
 * [Documentation](#documentation)
 * [Installation](#installation)
 * [Testing](#testing)
+* [Releasing](#releasing)
 
 ## Documentation
 
@@ -58,3 +59,13 @@ The `unit-tests` recipe in `Makefile` includes a minimum code coverage threshold
 `prefect-saturn`'s unit tests mock out its interactions with the rest of Saturn Cloud. Integration tests that test those interactions contain some sensitive information, and are stored in a private repository.
 
 If you experience issues using `prefect-saturn` and Saturn Cloud, please see [the Saturn documentation](#documentation) or contact us at by following the `Contact Us` navigation at https://www.saturncloud.io/s.
+
+## Releasing
+
+This section describes how to release a new version of `prefect-saturn` to PyPi. It is intended only for maintainers.
+
+1. Open a new pull request which bumps the version in `VERSION`. Merge that PR.
+2. [Create a new release](https://github.com/saturncloud/prefect-saturn/releases/new)
+    - the tag should be a version number, like `0.0.1`
+    - choose the target from "recent commits", and select the most recent commit on `main`
+3. Once this release is created, a GitHub Actions build will automatically start. That build publishes a release to PyPi.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # prefect-saturn
 
-![GitHub Actions](https://github.com/saturncloud/prefect-saturn/workflows/GitHub%20Actions/badge.svg)
+![GitHub Actions](https://github.com/saturncloud/prefect-saturn/workflows/GitHub%20Actions/badge.svg) [![PyPI Version](https://img.shields.io/pypi/v/prefect-saturn.svg)](https://pypi.org/project/prefect-saturn)
 
 `prefect-saturn` is a Python package that makes it easy to run Prefect Cloud flows on a Dask cluster with Saturn Cloud.
+
+
+## Getting Started
+
+`prefect-saturn` is available on PyPi.
+
+```shell
+pip install prefect-saturn
+```
 
 `prefect-saturn` can be installed directly from GitHub
 
 ```shell
 pip install git+https://github.com/saturncloud/prefect-saturn.git@main
 ```
+
+## Contributing
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for documentation on how to test and contribute to `prefect-saturn`.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("VERSION", "r") as f:
     version = f.read().strip()
 
 install_requires = ["cloudpickle", "dask-saturn>=0.0.4", "prefect", "requests"]
-testing_deps = ["pytest"]
+testing_deps = ["pytest", "pytest-cov", "responses"]
 
 setup(
     name="prefect-saturn",
@@ -43,6 +43,6 @@ setup(
     python_requires=">=3.6",
     extras_require={"dev": install_requires + testing_deps},
     test_suite="tests",
-    test_require=["pytest", "pytest-cov", "responses"],
+    test_require=testing_deps,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name="prefect-saturn",
     version=version,
     maintainer="Saturn Cloud Developers",
-    maintainer_email="dev@saturncloud.io",
+    maintainer_email="open-source@saturncloud.io",
     license="BSD 3-clause",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR introduces a GitHub Actions workflow for publishing to PyPi. A PyPi secret has been set up in the repo settings, for use with this template.

## How does this PR improve `prefect-saturn`?

This PR automates publishing of the project so users don't have to rely on GitHub to install the package.
