### PR TITLE
Create job spec using run_job_spec endpoint

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -218,38 +218,9 @@ class PrefectCloudIntegration:
         cluster_kwargs = cluster_kwargs or {"n_workers": 1}
         adapt_kwargs = adapt_kwargs or {"minimum": 1, "maximum": 2}
 
-        # setting unique_job_name=True on the environment is enough to guarantee
-        # uniqueness for this job name
-        flow_hash = self._hash_flow(flow)
-        job_name = f"pct-{flow_hash}"
-
-        # template for the jobs that handle flow runs
-        template_content = {
-            "apiVersion": "batch/v1",
-            "kind": "Job",
-            "metadata": {"name": job_name, "labels": {"identifier": "", "flow_run_id": ""}},
-            "spec": {
-                "template": {
-                    "metadata": {"labels": {"identifier": ""}},
-                    "spec": {
-                        "restartPolicy": "Never",
-                        "containers": [
-                            {
-                                "name": "flow-container",
-                                "image": "",
-                                "command": [],
-                                "args": [],
-                                "env": [{"name": "BASE_URL", "value": self._base_url}],
-                            }
-                        ],
-                    },
-                }
-            },
-        }
-
-        # get complete job spec with Saturn details from Atlas
+        # get job spec with Saturn details from Atlas
         url = f"{self._saturn_base_url}/api/prefect_cloud/flows/{self._saturn_flow_id}/run_job_spec"
-        response = self._session.post(url=url, json={"job_spec": template_content},)
+        response = self._session.get(url=url)
         response.raise_for_status()
         job_dict = response.json()
 

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -12,15 +12,13 @@ from requests.adapters import HTTPAdapter
 from requests.models import Response
 from requests.packages.urllib3.util.retry import Retry
 
-
 import cloudpickle
-import yaml
-
 from prefect import Flow
 from prefect.client import Client
 from prefect.engine.executors import DaskExecutor
 from prefect.environments.storage import Docker
 from prefect.environments import KubernetesJobEnvironment
+import yaml
 
 from .messages import Errors
 

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -219,8 +219,8 @@ class PrefectCloudIntegration:
         adapt_kwargs = adapt_kwargs or {"minimum": 1, "maximum": 2}
 
         # get job spec with Saturn details from Atlas
-        url = f"{self._saturn_base_url}/api/prefect_cloud/flows/{self._saturn_flow_id}/run_job_spec"
-        response = self._session.get(url=url)
+        url = f"{self._base_url}/api/prefect_cloud/flows/{self._saturn_flow_id}/run_job_spec"
+        response = self._session.get(url=url,)
         response.raise_for_status()
         job_dict = response.json()
 

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -217,8 +217,8 @@ class PrefectCloudIntegration:
         adapt_kwargs = adapt_kwargs or {"minimum": 1, "maximum": 2}
 
         # get job spec with Saturn details from Atlas
-        url = f"{self._base_url}/api/prefect_cloud/flows/{self._saturn_flow_id}/run_job_spec"
-        response = self._session.get(url=url,)
+        url = f"{self._base_url}api/prefect_cloud/flows/{self._saturn_flow_id}/run_job_spec"
+        response = self._session.get(url=url)
         response.raise_for_status()
         job_dict = response.json()
 

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -211,7 +211,7 @@ class PrefectCloudIntegration:
         flow: Flow,
         cluster_kwargs: Optional[Dict[str, Any]] = None,
         adapt_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> KubernetesJobEnvironment:
+    ) -> Flow:
         """
         Get an environment that customizes the execution of a Prefect flow run.
         """

--- a/tests/run-job-spec.yaml
+++ b/tests/run-job-spec.yaml
@@ -1,0 +1,15 @@
+# test output from /api/prefect_cloud/flows/{id}/run_job_spec in Atlas
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "pct-df035c2c"
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: flow-container
+          image: ""
+          command: []
+          args: []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ import prefect_saturn
 import random
 import responses
 import uuid
+import yaml
 
 from copy import deepcopy
 from typing import Any, Dict, Optional
@@ -123,6 +124,23 @@ BUILD_STORAGE_RESPONSE = {
     "url": f"{os.environ['BASE_URL']}/api/prefect_cloud/flows/{TEST_FLOW_ID}/store",
     "status": 201,
 }
+
+
+# ------------------------------------------ #
+# /api/prefect_cloud/flows/{id}/run_job_spec #
+# ------------------------------------------ #
+def REGISTER_RUN_JOB_SPEC_RESPONSE(status: int) -> Dict[str, Any]:
+    run_job_spec_file = os.path.join(os.path.dirname(__file__), "run-job-spec.yaml")
+    with open(run_job_spec_file, "r") as file:
+        run_job_spec = yaml.load(file, Loader=yaml.FullLoader)
+
+    base_url = os.environ["BASE_URL"]
+    return {
+        "method": responses.GET,
+        "url": f"{base_url}/api/prefect_cloud/flows/{TEST_FLOW_ID}/run_job_spec",
+        "json": run_job_spec,
+        "status": status,
+    }
 
 
 class MockClient:
@@ -337,6 +355,7 @@ def test_build_environment():
         responses.add(**CURRENT_IMAGE_RESPONSE)
         responses.add(**REGISTER_FLOW_RESPONSE())
         responses.add(**SATURN_DETAILS_RESPONSE)
+        responses.add(**REGISTER_RUN_JOB_SPEC_RESPONSE(200))
 
         integration = prefect_saturn.PrefectCloudIntegration(
             prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?
Changes the creation method for the run flow job to refer to Atlas for Saturn specific details.
Instead of this repo knowing about Saturn specific details, we refer to an Atlas endpoint to fill in the details to the passed template, and pass it back.

Closes CU-9pdj8h
