### PR TITLE
make sure kubernetes is present in docker storage

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -189,7 +189,7 @@ class PrefectCloudIntegration:
             registry_url=saturn_details["registry_url"],
             prefect_directory="/tmp",
             env_vars={"SATURN_TOKEN": "placeholder-token", "BASE_URL": "placeholder-url"},
-            python_dependencies=["kubernetes"]
+            python_dependencies=["kubernetes"],
         )
         return flow
 

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -189,6 +189,7 @@ class PrefectCloudIntegration:
             registry_url=saturn_details["registry_url"],
             prefect_directory="/tmp",
             env_vars={"SATURN_TOKEN": "placeholder-token", "BASE_URL": "placeholder-url"},
+            python_dependencies=["kubernetes"]
         )
         return flow
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -370,6 +370,7 @@ def test_add_storage():
         assert flow.storage.image_name == integration.saturn_details["image_name"]
         assert flow.storage.registry_url == TEST_REGISTRY_URL
         assert flow.storage.prefect_directory == "/tmp"
+        assert "kubernetes" in flow.storage.python_dependencies
         assert "BASE_URL" in flow.storage.env_vars.keys()
         assert "SATURN_TOKEN" in flow.storage.env_vars.keys()
 


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR fixes an issue where flow storage might fail to build if the image used with `Docker` storage does not have the Python kubernetes library installed.

## How does this PR improve `prefect-saturn`?

This makes it less likely that building storage will fail, in a way that does not introduce any new knowledge or maintenance burden for users.