### PR TITLE
improve docs on testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ To develop `prefect-saturn`, install it locally with the following command
 python setup.py develop
 ```
 
+NOTE: If you have previously `pip install`'d `prefect-saturn`, some steps in this project might not work for you. Run `pip uninstall -y prefect-saturn` to remove any `pip install`'d versions.
+
 ## Testing
 
 Every commit to this repository is tested automatically using continuous integration (CI). All CI checks must pass to for a pull request to be accepted.

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ lint:
 
 .PHONY: unit-tests
 unit-tests:
+	pip uninstall -y prefect-saturn
 	python setup.py develop
 	pytest --cov=prefect_saturn --cov-fail-under=80 tests/
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 `prefect-saturn` is a Python package that makes it easy to run [Prefect Cloud](https://www.prefect.io/cloud/) flows on a Dask cluster with [Saturn Cloud](https://www.saturncloud.io/).
 
-
 ## Getting Started
 
 `prefect-saturn` is available on PyPi.


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* adds docs on common issues people might face running the tests
* added a defensive `pip uninstall prefect-saturn` to `make unit-tests` to hopefully avoid things like "I fixed the code and the tests are still broken" or "the test run but coverage is 0"

## How does this PR improve `prefect-saturn`?

This PR reduces some friction in developing `prefect-saturn`.
