### PR TITLE
Add add_environment_tests

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -217,6 +217,9 @@ class PrefectCloudIntegration:
         cluster_kwargs = cluster_kwargs or {"n_workers": 1}
         adapt_kwargs = adapt_kwargs or {"minimum": 1, "maximum": 2}
 
+        if self._saturn_flow_id is None:
+            raise RuntimeError(Errors.NOT_REGISTERED)
+
         # get job spec with Saturn details from Atlas
         url = f"{self._base_url}api/prefect_cloud/flows/{self._saturn_flow_id}/run_job_spec"
         response = self._session.get(url=url)


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR adds additional tests for the `add_environment` method in core. It also adds a check in `add_environment` similar to other functions that throws a `RuntimeError` if there is no saturn_flow_id.
