### PR TITLE
fix linting stuff and add scheduled CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
     - main
+  schedule:
+    # Run every Monday morning at 11:00a UTC, 6:00a CST
+    - cron: '0 11 * * 1'
 
 jobs:
   test:

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -55,16 +55,16 @@ class PrefectCloudIntegration:
     def __init__(self, prefect_cloud_project_name: str):
         try:
             SATURN_TOKEN = os.environ["SATURN_TOKEN"]
-        except KeyError:
-            raise RuntimeError(Errors.missing_env_var("SATURN_TOKEN"))
+        except KeyError as err:
+            raise RuntimeError(Errors.missing_env_var("SATURN_TOKEN")) from err
 
         try:
             base_url = os.environ["BASE_URL"]
             if not base_url.endswith("/"):
                 base_url += "/"
             self._base_url: str = base_url
-        except KeyError:
-            raise RuntimeError(Errors.missing_env_var("BASE_URL"))
+        except KeyError as err:
+            raise RuntimeError(Errors.missing_env_var("BASE_URL")) from err
 
         self.prefect_cloud_project_name: str = prefect_cloud_project_name
         self._saturn_flow_id: Optional[str] = None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,7 +41,8 @@ TEST_FLOW = Flow(TEST_FLOW_NAME, tasks=[hello_task])
 # /api/prefect_cloud/flows #
 # ------------------------ #
 def REGISTER_FLOW_RESPONSE(
-    flow_id: Optional[str] = None, status: Optional[int] = None,
+    flow_id: Optional[str] = None,
+    status: Optional[int] = None,
 ) -> Dict[str, Any]:
     return {
         "method": responses.PUT,


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* adds weekly CI that will run on Monday mornings (U.S. timezones)
* re-runs `make format` with the newest version of [`black`](https://pypi.org/project/black/#history)
* Fixes the two minor linting things found by `pylint`. See [`raise-missing-from` here ](http://pylint.pycqa.org/en/latest/technical_reference/features.html) and the PEP on [`Explicit Exception Chaining`]
    > "Consider explicitly re-raising using the 'from' keyword (raise-missing-from)"

## How does this PR improve `prefect-saturn`?

This PR fixes small new linting issues introduced in versions of `black` and `pylint` that have been released since the last time a pull request was merged in this repo. Without these fixes, these issues would turn up on the next pull request submitted.

To be sure we keep up with such fixes and (more importantly) with changes to `prefect`, this PR proposes introducing a schedule for CI. As of this PR, this repo's tests would run on every pull request, merge to `main`, AND every Monday morning (U.S. timezones). The job always installs the latest version of all dependencies, so this can help us to catch issues soon after they're introduced.