### PR TITLE
fix GitHub Actions conda setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Set up Python 3.7
         if: matrix.task != 'todo-checks'
-        uses: s-weigand/setup-conda@v1.0.3
+        uses: s-weigand/setup-conda@v1
         with:
           python-version: 3.7
       - name: linting


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

Changes the tag used for the `setup-conda` GitHub Action to `v1`, so that it always picks up the latest release in https://github.com/s-weigand/setup-conda/releases.

## How does this PR improve `prefect-saturn`?

Without this PR, this project's CI is broken, because GitHub disabled some features used by that action.

```text
Error: Unable to process command '##[add-path]/usr/share/miniconda' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '##[add-path]/usr/share/miniconda/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
