### PR TITLE
add tests on describe_sizes()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,15 @@ make unit-tests
 
 The `unit-tests` recipe in `Makefile` includes a minimum code coverage threshold. All pull requests must pass all tests with more than this level of code coverage. The current coverage is reported in the results of `make unit-tests`.
 
+To get a clickable report that shows which lines are not covered by tests, use the following:
+
+```shell
+make unit-tests
+coverage html
+```
+
+Open the file `htmlcov/index.html` to see a coverage report.
+
 ### Integration tests
 
 `prefect-saturn`'s unit tests mock out its interactions with the rest of Saturn Cloud. Integration tests that test those interactions contain some sensitive information, and are stored in a private repository.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 unit-tests:
 	pip uninstall -y prefect-saturn || true
 	python setup.py develop
-	pytest --cov=prefect_saturn --cov-fail-under=80 tests/
+	pytest --cov=prefect_saturn --cov-fail-under=100 tests/
 
 .PHONY: test
 test: clean lint unit-tests

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -122,9 +122,9 @@ def SERVER_SIZES_RESPONSE(status: int) -> Dict[str, str]:
         "json": {
             "sizes": {
                 "medium": "medium - 2 cores - 4 GB RAM",
-                "8xlarge": "8XLarge - 32 cores - 256 GB RAM"
+                "8xlarge": "8XLarge - 32 cores - 256 GB RAM",
             }
-        }
+        },
     }
 
 
@@ -492,10 +492,10 @@ def test_describe_sizes_raises_informative_error_on_failure():
     # with raises(HTTPError, match="Not Found for url"):
     with raises(HTTPError, match="Unauthorized"):
         responses.add(**SERVER_SIZES_RESPONSE(status=401))
-        result = prefect_saturn.describe_sizes()
+        prefect_saturn.describe_sizes()
 
     failure_response = SERVER_SIZES_RESPONSE(500)
     failure_response["method_or_response"] = failure_response.pop("method")
     responses.replace(**failure_response)
     with raises(HTTPError, match="Server Error"):
-        result = prefect_saturn.describe_sizes()
+        prefect_saturn.describe_sizes()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -489,7 +489,6 @@ def test_describe_sizes_successful():
 
 @responses.activate
 def test_describe_sizes_raises_informative_error_on_failure():
-    # with raises(HTTPError, match="Not Found for url"):
     with raises(HTTPError, match="Unauthorized"):
         responses.add(**SERVER_SIZES_RESPONSE(status=401))
         prefect_saturn.describe_sizes()


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* adds unit tests on `describe_sizes()`
* bumps test coverage threshold back to 100% (was lowered in #23)
* adds docs on generating a clickable coverage report

## How does this PR improve `prefect-saturn`?

This PR returns `prefect-saturn`'s test coverage to 100%, so that the types of issues that can be caught by tests (like typos in the names of keys used to subset dictionaries), are caught.

It also adds tests ensuring that `describe_sizes()` raises informative errors if Saturn responds with a 4xx or 5xx response, so that users will have some information about what went wrong.