### PR TITLE
explicitly set autoscale=False for DaskExecutor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint:
 unit-tests:
 	pip uninstall -y prefect-saturn || true
 	python setup.py develop
-	pytest --cov=prefect_saturn --cov-fail-under=80 tests/
+	pytest --cov=prefect_saturn --cov-fail-under=100 tests/
 
 .PHONY: test
 test: clean lint unit-tests

--- a/README.md
+++ b/README.md
@@ -2,9 +2,26 @@
 
 ![GitHub Actions](https://github.com/saturncloud/prefect-saturn/workflows/GitHub%20Actions/badge.svg) [![PyPI Version](https://img.shields.io/pypi/v/prefect-saturn.svg)](https://pypi.org/project/prefect-saturn)
 
-`prefect-saturn` is a Python package that makes it easy to run [Prefect Cloud](https://www.prefect.io/cloud/) flows on a Dask cluster with [Saturn Cloud](https://www.saturncloud.io/).
+`prefect-saturn` is a Python package that makes it easy to run [Prefect Cloud](https://www.prefect.io/cloud/) flows on a Dask cluster with [Saturn Cloud](https://www.saturncloud.io/). For a detailed tutorial, see ["Fault-Tolerant Data Pipelines with Prefect Cloud
+"](https://www.saturncloud.io/docs/tutorials/prefect-cloud/).
+
+## Installation
+
+`prefect-saturn` is available on PyPi.
+
+```shell
+pip install prefect-saturn
+```
+
+`prefect-saturn` can be installed directly from GitHub
+
+```shell
+pip install git+https://github.com/saturncloud/prefect-saturn.git@main
+```
 
 ## Getting Started
+
+`prefect-saturn` is intended for use inside a [Saturn Cloud](https://www.saturncloud.io/) environment, such as a Jupyter notebook.
 
 ```python
 import prefect
@@ -32,19 +49,31 @@ flow.register(
 )
 ```
 
-## Installation
+### Customize Dask
 
-`prefect-saturn` is available on PyPi.
+You can customize the size and behavior of the Dask cluster used to run prefect flows. `prefect_saturn.PrefectCloudIntegration.register_flow_with_saturn()` accepts to arguments to accomplish this:
 
-```shell
-pip install prefect-saturn
+* `dask_cluster_kwargs`: keyword arguments to pass to the constructor [`dask_saturn.SaturnCluster`](https://github.com/saturncloud/dask-saturn/blob/936c91d54964f578b7224fa9c6fea7ea812e47d7/dask_saturn/core.py#L68-L94).
+* `dask_adapt_kwargs`: keyword arguments used to configure ["Adaptive Scaling"](https://docs.dask.org/en/latest/setup/adaptive.html)
+
+For example, the code below tells Saturn that this flow should run on a Dask cluster with 3 xlarge workers, and that prefect should shut down the cluster once the flow run has finished.
+
+```python
+flow = integration.register_flow_with_saturn(
+    flow=flow,
+    dask_cluster_kwargs={
+        "n_workers": 3,
+        "worker_size": "xlarge",
+        "autoclose": True
+    }
+)
+
+flow.register(
+    project_name=project_name,
+    labels=["saturn-cloud"]
+)
 ```
 
-`prefect-saturn` can be installed directly from GitHub
-
-```shell
-pip install git+https://github.com/saturncloud/prefect-saturn.git@main
-```
 
 ## Contributing
 

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -272,9 +272,7 @@ class PrefectCloudIntegration:
 
         if dask_cluster_kwargs is None:
             dask_cluster_kwargs = default_cluster_kwargs
-        elif dask_cluster_kwargs == {}:
-            pass
-        else:
+        elif dask_cluster_kwargs != {}:
             default_cluster_kwargs.update(dask_cluster_kwargs)
             dask_cluster_kwargs = default_cluster_kwargs
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -339,18 +339,18 @@ def test_get_environment_dask_kwargs():
         flow = TEST_FLOW.copy()
         flow = integration.register_flow_with_saturn(
             flow=flow,
-            dask_cluster_kwargs={"n_workers": 8},
+            dask_cluster_kwargs={"n_workers": 8, "autoclose": True},
             dask_adapt_kwargs={"minimum": 3, "maximum": 3},
         )
 
         assert isinstance(flow.environment, KubernetesJobEnvironment)
         assert isinstance(flow.environment.executor, DaskExecutor)
-        assert flow.environment.executor.cluster_kwargs == {"n_workers": 8}
+        assert flow.environment.executor.cluster_kwargs == {"n_workers": 8, "autoclose": True}
         assert flow.environment.executor.adapt_kwargs == {"minimum": 3, "maximum": 3}
 
 
 @responses.activate
-def test_get_environment_dask_adaptive_scaling_off_by_default():
+def test_get_environment_dask_adaptive_scaling_and_autoclosing_off_by_default():
     with patch("prefect_saturn.core.Client", new=MockClient):
         responses.add(**REGISTER_FLOW_RESPONSE())
         responses.add(**BUILD_STORAGE_RESPONSE())
@@ -364,7 +364,7 @@ def test_get_environment_dask_adaptive_scaling_off_by_default():
 
         assert isinstance(flow.environment, KubernetesJobEnvironment)
         assert isinstance(flow.environment.executor, DaskExecutor)
-        assert flow.environment.executor.cluster_kwargs == {"n_workers": 1}
+        assert flow.environment.executor.cluster_kwargs == {"n_workers": 1, "autoclose": False}
         assert flow.environment.executor.adapt_kwargs == {}
 
 


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* makes `autoclose = False` the explicit default behavior of `prefect-saturn`.
* adds examples in the README of how to use customize the Dask cluster used by `DaskExecutor`
* re-arranges README sections so that installation comes first
* fixes some small mistakes in documentation

## How does this PR improve `prefect-saturn`?

`autoclose=False` is already the default behavior because this library doesn't currently specify `autoclose`, and the default in `dask-saturn` is `autoclose=False` (https://github.com/saturncloud/dask-saturn/blob/936c91d54964f578b7224fa9c6fea7ea812e47d7/dask_saturn/core.py#L109).

This just makes it explicit, so that even if the default changes in `dask-saturn`, this library's behavior is unchanged. `prefect-saturn` prefers `autoclose=False` because one of Prefect's selling points is that it can handle concurrent runs of the same flow. If you kick off two runs of a flow, having `autoclose=True` means that whichever one finishes first will shut down the cluster, potentially breaking the other run.

### Notes for reviewers

I've tested this with our internal Prefect Cloud integration tests and confirmed that if you pass `autoclose=True`, the Dask cluster from the flow is shut down. And that if you don't explicitly pass that argument, the Dask cluster isn't shut down.