### PR TITLE
centralize CI configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,10 @@ format:
 
 .PHONY: lint
 lint:
-	flake8 --count --max-line-length 100 --exclude prefect-fork .
-	black --check --diff --line-length 100 .
-	mypy --ignore-missing-imports .
-	# pylint disables:
-	#   * C0301: line too long
-	#   * C0103: snake-case naming
-	#   * C0330: wrong hanging indent before block
-	#   * E0401: unable to import
-	#   * R0903: too few public methods
-	#   * W0212: access to protected member
-	pylint --disable=C0103,C0301,C0330,E0401,R0903,W0212 prefect_saturn/
+	flake8 --count .
+	black --check --diff .
+	mypy .
+	pylint prefect_saturn/
 
 .PHONY: unit-tests
 unit-tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,25 @@
+[flake8]
+max-line-length = 100
+
 [metadata]
 license_files = LICENSE
+
+[mypy]
+ignore_missing_imports = True
+
+[pylint.MESSAGES_CONTROL]
+
+# This controls the checks that pylint ignores.
+#
+# If you add to this list, please keep it in
+# alphabetical order.
+#
+# to list all possibilities, run:
+#
+#     pylint --list-msg
+#
+disable=
+    import-error,
+    invalid-name,
+    protected-access,
+    too-few-public-methods

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 
 from prefect import task, Flow
 from prefect.engine.executors import DaskExecutor
-from prefect.environments import KubernetesJobEnvironment, LocalEnvironment
+from prefect.environments import KubernetesJobEnvironment
 from prefect.environments.storage import Webhook
 from pytest import raises
 from requests.exceptions import HTTPError

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -468,7 +468,6 @@ def test_register_flow_with_saturn_does_everything():
 
         flow = TEST_FLOW.copy()
         assert flow.storage is None
-        assert isinstance(flow.environment, LocalEnvironment)
 
         flow = integration.register_flow_with_saturn(flow=flow, instance_size="large")
         assert integration._saturn_flow_id == test_flow_id


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

Moves configuration for `black`, `flake8`, `mypy`, and `pylint` out of `Makefile` and into root-level config files.

## How does this PR improve `prefect-saturn`?

This makes the behavior of these linters consistent regardless of how you run them. Now the behavior from `make lint` will be the same as, say, `pylint prefect_saturn/`.

I chose to put as many as I could in `setup.cg` instead of introducing individual files like `mypy.ini` and `.flake8` to minimize the number of files you have to think about.