### PR TITLE
[DEV-1227] Replace pyyaml

### DIFF
--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -15,7 +15,7 @@ from prefect.client import Client
 from prefect.engine.executors import DaskExecutor
 from prefect.environments.storage import Webhook
 from prefect.environments import KubernetesJobEnvironment
-import yaml
+from ruamel import yaml
 
 from .settings import Settings
 from .messages import Errors
@@ -340,7 +340,7 @@ class PrefectCloudIntegration:
 
         local_tmp_file = "/tmp/prefect-flow-run.yaml"
         with open(local_tmp_file, "w") as f:
-            f.write(yaml.dump(job_dict))
+            yaml.dump(job_dict, stream=f, Dumper=yaml.RoundTripDumper)
 
         # saturn_flow_id is used by Saturn's custom Prefect agent
         k8s_environment = KubernetesJobEnvironment(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,13 @@ with open("VERSION", "r") as f:
     version = f.read().strip()
 
 # prefect has to be 0.13.0 or newer to get Webhook storage
-install_requires = ["cloudpickle", "dask-saturn>=0.0.4", "prefect>0.13.0", "requests"]
+install_requires = [
+    "cloudpickle",
+    "dask-saturn>=0.0.4",
+    "prefect>0.13.0",
+    "requests",
+    "ruamel.yaml",
+]
 testing_deps = ["pytest", "pytest-cov", "responses"]
 
 setup(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,6 @@ import prefect_saturn
 import random
 import responses
 import uuid
-import yaml
 
 from typing import Any, Dict, Optional
 
@@ -16,6 +15,8 @@ from pytest import raises
 from requests.exceptions import HTTPError
 from unittest.mock import patch
 from urllib.parse import urlparse
+from ruamel import yaml
+
 
 FLOW_LABELS = [urlparse(os.environ["BASE_URL"]).hostname, "saturn-cloud", "webhook-flow-storage"]
 
@@ -100,7 +101,7 @@ def BUILD_STORAGE_FAILURE_RESPONSE(
 def REGISTER_RUN_JOB_SPEC_RESPONSE(status: int, flow_id: str = TEST_FLOW_ID) -> Dict[str, Any]:
     run_job_spec_file = os.path.join(os.path.dirname(__file__), "run-job-spec.yaml")
     with open(run_job_spec_file, "r") as file:
-        run_job_spec = yaml.load(file, Loader=yaml.FullLoader)
+        run_job_spec = yaml.load(file, Loader=yaml.RoundTripLoader)
 
     base_url = os.environ["BASE_URL"]
     return {


### PR DESCRIPTION
Unlike PyYAML, ruamel.yaml supports:
* YAML <= 1.2. PyYAML only supports YAML <= 1.1
This is vital, as YAML 1.2 intentionally breaks backward compatibility
with YAML 1.1 in several edge cases. This would usually be a bad thing.
In this case, this renders YAML 1.2 a strict superset of JSON. Since
YAML 1.1 is not a strict superset of JSON, this is a good thing.
* Roundtrip preservation
When calling yaml.dump() to dump a dictionary loaded by a prior call
to yaml.load():

See more details at https://yaml.readthedocs.io/en/latest/pyyaml.html
