### PR TITLE
CI: Install deps from spec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.task == 'unit-tests'
         shell: bash
         run: |
-          pip install --upgrade cloudpickle pytest pytest-cov responses
+          pip install -I --upgrade -e .[test]
           make unit-tests
       - name: test source distribution
         if: matrix.task == 'sdist'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=find_packages(),
     install_requires=install_requires,
     python_requires=">=3.7",
-    extras_require={"dev": install_requires + testing_deps},
+    extras_require={"dev": install_requires + testing_deps, "test": testing_deps},
     test_suite="tests",
     tests_require=testing_deps,
     zip_safe=False,


### PR DESCRIPTION
This proposes to install deps from setuptools spec, in order to avoid having duplicated places for setting dependencies.