### PR TITLE
remove TODO check in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,15 +51,3 @@ jobs:
         run: |
           python setup.py sdist
           pip install dist/prefect-saturn-$(cat VERSION).tar.gz
-      - name: todo-checks
-        if: matrix.task == 'todo-checks'
-        shell: bash
-        run: |
-          num_todos=$(git grep -i -E "TODO|FIXME" | wc -l)
-          echo "found ${num_todos} TODOs in code"
-          num_allowed=10
-          if [[ $num_todos -gt $num_allowed ]]; then
-            exit ${num_todos}
-          else
-            exit 0
-          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,11 @@ jobs:
         include:
           - task: linting
           - task: sdist
-          - task: todo-checks
           - task: unit-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Set up Python 3.7
-        if: matrix.task != 'todo-checks'
         uses: s-weigand/setup-conda@v1
         with:
           python-version: 3.7

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -21,7 +21,6 @@ from .settings import Settings
 from .messages import Errors
 
 
-# TODO: do stuff
 def _session(token: str) -> Session:
     retry_logic = HTTPAdapter(max_retries=Retry(total=3))
     session = Session()

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -21,6 +21,7 @@ from .settings import Settings
 from .messages import Errors
 
 
+# TODO: do stuff
 def _session(token: str) -> Session:
     retry_logic = HTTPAdapter(max_retries=Retry(total=3))
     session = Session()


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

Removes the TODO checks in this project's CI. `pylint` already checks for TODO / FIXME comments, so the check removed in this PR isn't providing any value.

## How does this PR improve `prefect-saturn`?

This simplifies the GitHub Actions config to reduce the risk of errors caused by failures in this unnecessary job. It also removes one job from this project's CI, which reduces this project's impact on Saturn's overall budget for GitHub Actions utilization.