### PR TITLE
fix mypy errors in tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -115,7 +115,7 @@ def REGISTER_RUN_JOB_SPEC_RESPONSE(status: int, flow_id: str = TEST_FLOW_ID) -> 
 # ----------------- #
 # /api/info/servers #
 # ------------------#
-def SERVER_SIZES_RESPONSE(status: int) -> Dict[str, str]:
+def SERVER_SIZES_RESPONSE(status: int) -> Dict[str, Any]:
     return {
         "method": responses.GET,
         "url": f"{os.environ['BASE_URL']}/api/info/servers",


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

Makes minor changes to test code, to fix these linting errors

```text
tests/test_core.py:122: error: Dict entry 2 has incompatible type "str": "int"; expected "str": "str"
tests/test_core.py:123: error: Dict entry 3 has incompatible type "str": "Dict[str, Dict[str, str]]"; expected "str": "str"
```

## How does this PR improve `prefect-saturn`?

This fixes an issue that is breaking Ci, which would need to be fixed by the next pull request to this project. See https://github.com/saturncloud/prefect-saturn/actions/runs/509222292.
