### PR TITLE
fix typo in _compat.py

### DIFF
--- a/prefect_saturn/_compat.py
+++ b/prefect_saturn/_compat.py
@@ -13,7 +13,7 @@ try:
 except (ImportError, ModuleNotFoundError):
     from prefect.environments.storage import Webhook  # noqa: F401
 
-# prefect.engine.executors was depreacted in prefect 0.14.x
+# prefect.engine.executors was deprecated in prefect 0.14.x
 try:
     from prefect.executors import DaskExecutor  # noqa: F401
 except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

Fixes a typo in a comment in `_compat.py`

## How does this PR improve `prefect-saturn`?

Typos can lead to things being missed when searching with GitHub search or tools like `git grep`.