### PR TITLE
reorganize executor access in tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -361,9 +361,11 @@ def test_get_environment_dask_kwargs():
         )
 
         assert isinstance(flow.environment, KubernetesJobEnvironment)
-        assert isinstance(flow.environment.executor, DaskExecutor)
-        assert flow.environment.executor.cluster_kwargs == {"n_workers": 8, "autoclose": True}
-        assert flow.environment.executor.adapt_kwargs == {"minimum": 3, "maximum": 3}
+
+        executor = flow.environment.executor
+        assert isinstance(executor, DaskExecutor)
+        assert executor.cluster_kwargs == {"n_workers": 8, "autoclose": True}
+        assert executor.adapt_kwargs == {"minimum": 3, "maximum": 3}
 
 
 @responses.activate
@@ -380,9 +382,11 @@ def test_get_environment_dask_adaptive_scaling_and_autoclosing_off_by_default():
         flow = integration.register_flow_with_saturn(flow=flow)
 
         assert isinstance(flow.environment, KubernetesJobEnvironment)
-        assert isinstance(flow.environment.executor, DaskExecutor)
-        assert flow.environment.executor.cluster_kwargs == {"n_workers": 1, "autoclose": False}
-        assert flow.environment.executor.adapt_kwargs == {}
+
+        executor = flow.environment.executor
+        assert isinstance(executor, DaskExecutor)
+        assert executor.cluster_kwargs == {"n_workers": 1, "autoclose": False}
+        assert executor.adapt_kwargs == {}
 
 
 @responses.activate
@@ -401,9 +405,11 @@ def test_get_environment_dask_kwargs_respects_empty_dict():
         )
 
         assert isinstance(flow.environment, KubernetesJobEnvironment)
-        assert isinstance(flow.environment.executor, DaskExecutor)
-        assert flow.environment.executor.cluster_kwargs == {}
-        assert flow.environment.executor.adapt_kwargs == {}
+
+        executor = flow.environment.executor
+        assert isinstance(executor, DaskExecutor)
+        assert executor.cluster_kwargs == {}
+        assert executor.adapt_kwargs == {}
 
 
 def test_get_environment_fails_if_flow_not_registered():
@@ -475,7 +481,9 @@ def test_register_flow_with_saturn_does_everything():
         assert integration._saturn_image == TEST_IMAGE
         assert isinstance(flow.storage, Webhook)
         assert isinstance(flow.environment, KubernetesJobEnvironment)
-        assert isinstance(flow.environment.executor, DaskExecutor)
+
+        executor = flow.environment.executor
+        assert isinstance(executor, DaskExecutor)
 
 
 @responses.activate


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* stores `flow.environment.executor` in a local variable that other tests references

## How does this PR improve `prefect-saturn`?

#34 will introduce the ability to use [the new `RunConfig`  pattern from `prefect`](https://medium.com/the-prefect-blog/prefect-0-14-0-improved-flow-run-configuration-af6c3caccd04). When configuring a flow with `RunConfig`, there is no concept of "environment". So, concretely, you'll have these two access patterns to get the executor for a flow:

* `prefect<0.14.0`: `flow.environment.executor`
* `prefect>=0.14.0`: `flow.executor`

This PR just replaces multiple uses of `flow.environment.executor` in tests, so that a few less lines need to be changed in #34 , making that PR a bit easier to review.