### PR TITLE
update versions of GitHub Actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,4 @@ include =
     *prefect_saturn/*
 
 omit =
-    */_compat.py
+    *_compat.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,9 @@
 # .coveragerc explained
-#     - https://coverage.readthedocs.io/en/coverage-4.2/config.html
-#     - https://coverage.readthedocs.io/en/coverage-4.2/source.html#source
+#     - https://coverage.readthedocs.io/en/coverage-5.5/config.html
 
 [run]
+include =
+    *prefect_saturn/*
+
 omit =
-    *_compat.py
+    */_compat.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.task == 'unit-tests'
         shell: bash
         run: |
-          pip install -I --upgrade -e .[test]
+          pip install -I --upgrade .[test]
           make unit-tests
       - name: test source distribution
         if: matrix.task == 'sdist'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,9 @@ jobs:
             python_version: 3.8
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set up Python 3.7
-        uses: s-weigand/setup-conda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python_version }}
       - name: linting

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: 3.7
     - name: Install build dependencies
@@ -28,7 +28,7 @@ jobs:
         sdist
         bdist_wheel
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         # Password is set in GitHub UI to an API secret for pypi
         user: __token__

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,8 @@ lint:
 
 .PHONY: unit-tests
 unit-tests:
-	pip uninstall -y prefect-saturn || true
-	python setup.py develop
-	pytest --cov=prefect_saturn --cov-fail-under=88 tests/
+	pip install --upgrade .
+	pytest --cov --cov-fail-under=88 tests/
 
 .PHONY: test
 test: clean lint unit-tests


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* updates version of `checkout` action used in this project's CI, from v1 (November 2019) to v2 (November 2020)
* switches conda action from `s-weigand/setup-conda` (last release October 2020) to `conda-incubator/setup-miniconda@v2` (last release March 2021)
* switches Python setup action from `actions/setup-python` to `conda-incubator/setup-miniconda`, for consistency with this repo and others in Saturn
* updates `pypa/gh-action-pypi-publish` from v1.3.1 (July 2020) to v1.4.2 (Feb 2021)
    - NOTE: unlike other actions, https://github.com/pypa/gh-action-pypi-publish/tags does not have a tag like `v1` or `stable` that is updated on new releases, so you have to spin to a very specific version

## How does this PR improve `prefect-saturn`?

Keeping up with newer versions of these Actions limits the risk that a change in GitHub Actions will break this project's CI pipelines. Authors of those actions monitor deprecation warnings from GitHub and release fixes for them.
