### PR TITLE
resolve deprecation warning from ruamel.yaml>=0.17.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,13 @@ jobs:
         run: |
           pip install --upgrade black flake8 mypy pylint
           make lint
+      # resolves error:
+      # "Cannot uninstall 'ruamel-yaml'. It is a distutils installed project"
+      - name: remove old ruamel.yaml
+        shell: bash
+        run: |
+          SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+          find ${SITE_PACKAGES} -type f,l -name 'ruamel*' -delete
       - name: unit-tests
         if: matrix.task == 'unit-tests'
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,8 @@ jobs:
         shell: bash
         run: |
           pip install -I --upgrade -e .[test]
-          pip install -I --upgrade 'ruamel.yaml${{ matrix.ruamel_yaml_version }}'
+          pip uninstall -y ruamel.yaml
+          pip install -I 'ruamel.yaml${{ matrix.ruamel_yaml_version }}'
           make unit-tests
       - name: test source distribution
         if: matrix.task == 'sdist'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
             python_version: 3.7
           - task: unit-tests
             prefect_version: ">0.13.0,<0.14.0"
-            ruamel_yaml_version: "<0.17.0"
-            name: "unit-tests (prefect 0.13.x, ruamel.yaml 0.16.x, Python 3.7)"
+            ruamel_yaml_version: "==0.16.0"
+            name: "unit-tests (prefect 0.13.x, ruamel.yaml 0.16.0, Python 3.7)"
             python_version: 3.7
           - task: unit-tests
             prefect_version: ">0.14.0,<0.15.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,15 +29,18 @@ jobs:
             python_version: 3.7
           - task: unit-tests
             prefect_version: ">0.13.0,<0.14.0"
-            name: "unit-tests (prefect 0.13.x, Python 3.7)"
+            ruamel_yaml_version: "<0.17.0"
+            name: "unit-tests (prefect 0.13.x, ruamel.yaml 0.16.x, Python 3.7)"
             python_version: 3.7
           - task: unit-tests
             prefect_version: ">0.14.0,<0.15.0"
-            name: "unit-tests (prefect 0.14.x, Python 3.7)"
+            ruamel_yaml_version: ">=0.17.7"
+            name: "unit-tests (prefect 0.14.x, ruamel.yaml latest, Python 3.7)"
             python_version: 3.7
           - task: unit-tests
             prefect_version: ""
-            name: "unit-tests (prefect latest, Python 3.8)"
+            ruamel_yaml_version: ">=0.17.7"
+            name: "unit-tests (prefect latest, ruamel.yaml latest, Python 3.8)"
             python_version: 3.8
     steps:
       - name: Checkout repository
@@ -57,6 +60,7 @@ jobs:
         shell: bash
         run: |
           pip install -I --upgrade -e .[test]
+          pip install -I --upgrade 'ruamel.yaml${{ matrix.ruamel_yaml_version }}'
           make unit-tests
       - name: test source distribution
         if: matrix.task == 'sdist'

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -13,7 +13,7 @@ import cloudpickle
 from prefect import Flow
 from prefect.client import Client
 
-from ruamel import yaml
+from ruamel.yaml import YAML
 
 from ._compat import DaskExecutor, KUBE_JOB_ENV_AVAILABLE, RUN_CONFIG_AVAILABLE, Webhook
 from .settings import Settings
@@ -370,7 +370,7 @@ class PrefectCloudIntegration:
 
         local_tmp_file = "/tmp/prefect-flow-run.yaml"
         with open(local_tmp_file, "w") as f:
-            yaml.dump(self._flow_run_job_spec, stream=f, Dumper=yaml.RoundTripDumper)
+            YAML().dump(self._flow_run_job_spec, stream=f)
 
         # saturn_flow_id is used by Saturn's custom Prefect agent
         k8s_environment = KubernetesJobEnvironment(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,7 +12,7 @@ from pytest import mark, raises
 from requests.exceptions import HTTPError
 from unittest.mock import patch
 from urllib.parse import urlparse
-from ruamel import yaml
+from ruamel.yaml import YAML
 
 from prefect_saturn._compat import (
     Webhook,
@@ -110,7 +110,7 @@ def BUILD_STORAGE_FAILURE_RESPONSE(
 def REGISTER_RUN_JOB_SPEC_RESPONSE(status: int, flow_id: str = TEST_FLOW_ID) -> Dict[str, Any]:
     run_job_spec_file = os.path.join(os.path.dirname(__file__), "run-job-spec.yaml")
     with open(run_job_spec_file, "r") as file:
-        run_job_spec = yaml.load(file, Loader=yaml.RoundTripLoader)
+        run_job_spec = YAML().load(file)
 
     base_url = os.environ["BASE_URL"]
     return {


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* changes the uses of `ruamel.yaml` in this library to the pattern recommended in this deprecation warning (observed with the newest release, 0.17.7):

```text
tests/test_core.py::test_register_flow_with_saturn_does_everything
  /home/jlamb/repos/saturn/prefect-saturn/tests/test_core.py:113: PendingDeprecationWarning: 
  load will be removed, use
  
    yaml=YAML(typ='unsafe', pure=True)
    yaml.load(...)
  
  instead
    run_job_spec = yaml.load(file, Loader=yaml.RoundTripLoader)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

* pins `ruamel.yaml` to 0.16.0 (July 2019) in one build, to test that this fix is compatible with a wide range of recent versions

## How does this PR improve `prefect-saturn`?

Removes a deprecation warning from users' logs, and ensures that `prefect-saturn` will not break when a future release of `ruamel.yaml` turns that DeprecationWarning into an error.