### PR TITLE
make GitHub Actions badge link to recent runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # prefect-saturn
 
-![GitHub Actions](https://github.com/saturncloud/prefect-saturn/workflows/GitHub%20Actions/badge.svg) [![PyPI Version](https://img.shields.io/pypi/v/prefect-saturn.svg)](https://pypi.org/project/prefect-saturn)
+[![GitHub Actions](https://github.com/saturncloud/prefect-saturn/workflows/GitHub%20Actions/badge.svg)](https://github.com/saturncloud/prefect-saturn/actions/workflows/main.yml?query=branch%3Amain)
+[![PyPI Version](https://img.shields.io/pypi/v/prefect-saturn.svg)](https://pypi.org/project/prefect-saturn)
 
 `prefect-saturn` is a Python package that makes it easy to run [Prefect Cloud](https://www.prefect.io/cloud/) flows on a Dask cluster with [Saturn Cloud](https://www.saturncloud.io/). For a detailed tutorial, see ["Fault-Tolerant Data Pipelines with Prefect Cloud
 "](https://www.saturncloud.io/docs/tutorials/prefect-cloud/).


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* makes the GitHub Actions status badge in the README link directly to the list of recent CI runs

## How does this PR improve `prefect-saturn`?

Now when you notice that this project's CI is failing...

![image](https://user-images.githubusercontent.com/7608904/121903065-8bd15780-cced-11eb-8f91-ea46e6b5835e.png)

... you can just click that badge and be taken to a list of recent runs

![image](https://user-images.githubusercontent.com/7608904/121903127-9a1f7380-cced-11eb-83d1-7f1468af3313.png)
