### PR TITLE
install library stubs for mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ format:
 
 .PHONY: lint
 lint:
+	pip install types-requests
 	flake8 --count .
 	black --check --diff .
 	mypy .


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

* adds installation of typing stub libraries (libraries that just contain type hints for the public interfaces of other libraries) to `make lint`

## How does this PR improve `prefect-saturn`?

* fixes CI job that has been broken since `mypy` 0.902 was released last week

See the logs below from the most recently scheduled build.

```text
mypy .
prefect_saturn/core.py:8: error: Library stubs not installed for "requests" (or incompatible with Python 3.8)
prefect_saturn/core.py:8: note: Hint: "python3 -m pip install types-requests"
prefect_saturn/core.py:8: note: (or run "mypy --install-types" to install all missing stub packages)
prefect_saturn/core.py:8: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
prefect_saturn/core.py:9: error: Library stubs not installed for "requests.adapters" (or incompatible with Python 3.8)
prefect_saturn/core.py:10: error: Library stubs not installed for "requests.packages.urllib3.util.retry" (or incompatible with Python 3.8)
tests/test_core.py:12: error: Library stubs not installed for "requests.exceptions" (or incompatible with Python 3.8)
Found 4 errors in 2 files (checked 9 source files)
make: *** [Makefile:17: lint] Error 1
```

https://github.com/saturncloud/prefect-saturn/runs/2819144241?check_suite_focus=true

### Notes for Reviewers

According to the discussion in https://github.com/python/mypy/issues/10601, a fix to `mypy` might be put out in the future that once again has `mypy` ignoring such errors when `--ignore-missing-imports` is passed. But instead of waiting on that fix, I think it is worth just installing the typing stub libraries here. That will get us slightly richer coverage from `mypy`.