### PR TITLE
Fix tenant_id attr for Prefect 15

### DIFF
--- a/prefect_saturn/_compat.py
+++ b/prefect_saturn/_compat.py
@@ -11,7 +11,7 @@ next major release of ``prefect``.
 try:
     from prefect.storage import Webhook  # noqa: F401
 except (ImportError, ModuleNotFoundError):
-    from prefect.environments.storage import Webhook  # noqa: F401
+    from prefect.environments.storage import Webhook  # type: ignore # noqa: F401
 
 # prefect.engine.executors was deprecated in prefect 0.14.x
 try:

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -5,11 +5,11 @@ This module contains the user-facing API for ``prefect-saturn``.
 import hashlib
 
 from typing import Any, Dict, List, Optional, Union
-from importlib.metadata import version
 from requests import Session
 from requests.adapters import HTTPAdapter
 
 import cloudpickle
+import prefect
 from prefect import Flow
 from prefect.client import Client
 
@@ -107,7 +107,7 @@ class PrefectCloudIntegration:
         flow with a given name, in a given Prefect Cloud project, for a given
         Prefect Cloud tenant.
         """
-        prefect_version = Version(version("prefect"))
+        prefect_version = Version(prefect.__version__)
 
         if parse("0.13.0") <= prefect_version < parse("0.15.0"):
             tenant_id = Client()._active_tenant_id  # type: ignore # pylint: disable=no-member

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -7,7 +7,6 @@ import hashlib
 from typing import Any, Dict, List, Optional, Union
 from requests import Session
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 
 import cloudpickle
 from prefect import Flow
@@ -27,7 +26,7 @@ if KUBE_JOB_ENV_AVAILABLE:
 
 
 def _session(token: str) -> Session:
-    retry_logic = HTTPAdapter(max_retries=Retry(total=3))
+    retry_logic = HTTPAdapter(max_retries=3)
     session = Session()
     session.mount("http://", retry_logic)
     session.mount("https://", retry_logic)

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -109,9 +109,9 @@ class PrefectCloudIntegration:
         """
         prefect_version = Version(prefect.__version__)
 
-        if parse("0.13.0") <= prefect_version < parse("0.15.0"):
+        if prefect_version < parse("0.15.0"):
             tenant_id = Client()._active_tenant_id  # type: ignore # pylint: disable=no-member
-        elif prefect_version >= parse("0.15.0"):
+        else:
             tenant_id = Client().tenant_id  # type: ignore
 
         identifying_content = [

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -106,7 +106,7 @@ class PrefectCloudIntegration:
         identifying_content = [
             self.prefect_cloud_project_name,
             flow.name,
-            Client()._active_tenant_id,  # pylint: disable=protected-access
+            Client().tenant_id,
         ]
         hasher = hashlib.sha256()
         hasher.update(cloudpickle.dumps(identifying_content))

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -38,7 +38,8 @@ def describe_sizes() -> Dict[str, Any]:
     """Returns available instance sizes for flows and dask clusters"""
     settings = Settings()
     res = _session(settings.SATURN_TOKEN).get(
-        url=f"{settings.BASE_URL}/api/info/servers", headers={"Content-Type": "application/json"},
+        url=f"{settings.BASE_URL}/api/info/servers",
+        headers={"Content-Type": "application/json"},
     )
     res.raise_for_status()
     response_json = res.json()
@@ -358,7 +359,9 @@ class PrefectCloudIntegration:
         return job_dict
 
     def _get_environment(
-        self, cluster_kwargs: Dict[str, Any], adapt_kwargs: Dict[str, Any],
+        self,
+        cluster_kwargs: Dict[str, Any],
+        adapt_kwargs: Dict[str, Any],
     ):
         """
         Get an environment that customizes the execution of a Prefect flow run.

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -109,7 +109,7 @@ class PrefectCloudIntegration:
         """
         prefect_version = Version(version("prefect"))
 
-        if prefect_version >= parse("0.13.0") and prefect_version < parse("0.15.0"):
+        if parse("0.13.0") <= prefect_version < parse("0.15.0"):
             tenant_id = Client()._active_tenant_id  # type: ignore
         elif prefect_version >= parse("0.15.0"):
             tenant_id = Client().tenant_id  # type: ignore

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -39,8 +39,7 @@ def describe_sizes() -> Dict[str, Any]:
     """Returns available instance sizes for flows and dask clusters"""
     settings = Settings()
     res = _session(settings.SATURN_TOKEN).get(
-        url=f"{settings.BASE_URL}/api/info/servers",
-        headers={"Content-Type": "application/json"},
+        url=f"{settings.BASE_URL}/api/info/servers", headers={"Content-Type": "application/json"},
     )
     res.raise_for_status()
     response_json = res.json()
@@ -360,9 +359,7 @@ class PrefectCloudIntegration:
         return job_dict
 
     def _get_environment(
-        self,
-        cluster_kwargs: Dict[str, Any],
-        adapt_kwargs: Dict[str, Any],
+        self, cluster_kwargs: Dict[str, Any], adapt_kwargs: Dict[str, Any],
     ):
         """
         Get an environment that customizes the execution of a Prefect flow run.

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -5,6 +5,7 @@ This module contains the user-facing API for ``prefect-saturn``.
 import hashlib
 
 from typing import Any, Dict, List, Optional, Union
+from importlib.metadata import version
 from requests import Session
 from requests.adapters import HTTPAdapter
 
@@ -12,7 +13,6 @@ import cloudpickle
 from prefect import Flow
 from prefect.client import Client
 
-from importlib.metadata import version
 from packaging.version import Version, parse
 
 from ruamel.yaml import YAML
@@ -110,7 +110,7 @@ class PrefectCloudIntegration:
         prefect_version = Version(version("prefect"))
 
         if parse("0.13.0") <= prefect_version < parse("0.15.0"):
-            tenant_id = Client()._active_tenant_id  # type: ignore
+            tenant_id = Client()._active_tenant_id  # type: ignore # pylint: disable=no-member
         elif prefect_version >= parse("0.15.0"):
             tenant_id = Client().tenant_id  # type: ignore
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ with open("VERSION", "r") as f:
 install_requires = [
     "cloudpickle",
     "dask-saturn>=0.0.4",
+    "importlib-metadata",
+    "packaging",
     "prefect>0.13.0",
     "requests",
     "ruamel.yaml",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ with open("VERSION", "r") as f:
 install_requires = [
     "cloudpickle",
     "dask-saturn>=0.0.4",
-    "importlib-metadata",
     "packaging",
     "prefect>0.13.0",
     "requests",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -51,7 +51,8 @@ TEST_FLOW = Flow(TEST_FLOW_NAME, tasks=[hello_task])
 # /api/prefect_cloud/flows #
 # ------------------------ #
 def REGISTER_FLOW_RESPONSE(
-    flow_id: Optional[str] = None, status: Optional[int] = None,
+    flow_id: Optional[str] = None,
+    status: Optional[int] = None,
 ) -> Dict[str, Any]:
     return {
         "method": responses.PUT,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,6 @@ import prefect_saturn
 import random
 import responses
 import uuid
-from importlib.metadata import version
 from packaging.version import Version, parse
 
 from typing import Any, Dict, Optional
@@ -29,7 +28,7 @@ if KUBE_JOB_ENV_AVAILABLE:
 if RUN_CONFIG_AVAILABLE:
     from prefect.run_configs import KubernetesRun
 
-PREFECT_VERSION = Version(version("prefect"))
+PREFECT_VERSION = Version(prefect.__version__)
 
 FLOW_LABELS = [urlparse(os.environ["BASE_URL"]).hostname, "saturn-cloud", "webhook-flow-storage"]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -51,8 +51,7 @@ TEST_FLOW = Flow(TEST_FLOW_NAME, tasks=[hello_task])
 # /api/prefect_cloud/flows #
 # ------------------------ #
 def REGISTER_FLOW_RESPONSE(
-    flow_id: Optional[str] = None,
-    status: Optional[int] = None,
+    flow_id: Optional[str] = None, status: Optional[int] = None,
 ) -> Dict[str, Any]:
     return {
         "method": responses.PUT,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -263,7 +263,7 @@ def test_hash_flow_hash_changes_if_tenant_id_changes():
 
     class OtherMockClient:
         def __init__(self):
-            if PREFECT_VERSION >= parse("0.13.0") and PREFECT_VERSION < parse("0.15.0"):
+            if parse("0.13.0") <= PREFECT_VERSION < parse("0.15.0"):
                 self._active_tenant_id = "some-other-garbage"
             elif PREFECT_VERSION >= parse("0.15.0"):
                 self.tenant_id = "some-other-garbage"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,9 +143,9 @@ def SERVER_SIZES_RESPONSE(status: int) -> Dict[str, Any]:
 
 class MockClient:
     def __init__(self):
-        if PREFECT_VERSION >= parse("0.13.0") and PREFECT_VERSION < parse("0.15.0"):
+        if PREFECT_VERSION < parse("0.15.0"):
             self._active_tenant_id = "543c5453-0a47-496a-9c61-a6765acef352"
-        elif PREFECT_VERSION >= parse("0.15.0"):
+        else:
             self.tenant_id = "543c5453-0a47-496a-9c61-a6765acef352"
 
 
@@ -262,9 +262,9 @@ def test_hash_flow_hash_changes_if_tenant_id_changes():
 
     class OtherMockClient:
         def __init__(self):
-            if parse("0.13.0") <= PREFECT_VERSION < parse("0.15.0"):
+            if PREFECT_VERSION < parse("0.15.0"):
                 self._active_tenant_id = "some-other-garbage"
-            elif PREFECT_VERSION >= parse("0.15.0"):
+            else:
                 self.tenant_id = "some-other-garbage"
 
     with patch("prefect_saturn.core.Client", new=OtherMockClient):


### PR DESCRIPTION
- [x] passes `make lint`
- [ ] adds tests to `tests/` (if appropriate)

I don't believe any tests need to be added.

## What does this PR change?

This PR changes the `Client()._active_tenant_id` > `Client().tenant_id` (when using Prefect >= `0.15`) since `_active_tenant_id` is no longer a property of Prefect's `Client` in `0.15`.

## How does this PR improve `prefect-saturn`?

This allows `prefect-saturn` to work with `prefect` in version `0.15` which removed the private attribute.