### PR TITLE
No default dask cluster

### DIFF
--- a/prefect_saturn/_compat.py
+++ b/prefect_saturn/_compat.py
@@ -15,9 +15,9 @@ except (ImportError, ModuleNotFoundError):
 
 # prefect.engine.executors was deprecated in prefect 0.14.x
 try:
-    from prefect.executors import DaskExecutor  # noqa: F401
+    from prefect.executors import DaskExecutor, LocalExecutor  # noqa: F401
 except (ImportError, ModuleNotFoundError):
-    from prefect.engine.executors import DaskExecutor  # noqa: F401
+    from prefect.engine.executors import DaskExecutor, LocalExecutor  # noqa: F401
 
 # prefect.run_configs was introduced in prefect 0.13.10
 try:

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -218,8 +218,7 @@ class PrefectCloudIntegration:
         :param flow: A Prefect ``Flow`` object
         :param dask_cluster_kwargs: Dictionary of keyword arguments
             to the ``dask_saturn.SaturnCluster`` constructor. If ``None``
-            (the default), the cluster will be created with
-            one worker (``{"n_workers": 1}``).
+            (the default), no cluster will be created.
         :param dask_adapt_kwargs: Dictionary of keyword arguments
             to pass to ``dask_saturn.SaturnCluster.adapt()``. If
             ``None`` (the default), adaptive scaling will not be used.
@@ -293,37 +292,33 @@ class PrefectCloudIntegration:
         The returned dict maps instance_size to a short description of the resources available on
         that size (e.g. {"medium": "Medium - 2 cores - 4 GB RAM", ...})
         """
-        default_cluster_kwargs = {"n_workers": 1, "autoclose": False}
-
-        if dask_cluster_kwargs is None:
-            dask_cluster_kwargs = default_cluster_kwargs
-        elif dask_cluster_kwargs != {}:
-            default_cluster_kwargs.update(dask_cluster_kwargs)
-            dask_cluster_kwargs = default_cluster_kwargs
-
-        if dask_adapt_kwargs is None:
-            dask_adapt_kwargs = {}
-
         self._set_flow_metadata(flow, instance_size=instance_size)
 
         storage = self._get_storage()
         flow.storage = storage
 
-        if RUN_CONFIG_AVAILABLE:
-            flow.executor = DaskExecutor(
+        executor = None
+        if dask_cluster_kwargs:
+            if dask_adapt_kwargs is None:
+                dask_adapt_kwargs = {}
+
+            executor = DaskExecutor(
                 cluster_class="dask_saturn.SaturnCluster",
                 cluster_kwargs=dask_cluster_kwargs,
                 adapt_kwargs=dask_adapt_kwargs,
             )
+
+        if RUN_CONFIG_AVAILABLE:
+            if executor:
+                flow.executor = executor
+
             flow.run_config = KubernetesRun(
                 job_template=self._flow_run_job_spec,
                 labels=self._saturn_flow_labels,
                 image=self._saturn_image,
             )
         else:
-            flow.environment = self._get_environment(
-                cluster_kwargs=dask_cluster_kwargs, adapt_kwargs=dask_adapt_kwargs
-            )
+            flow.environment = self._get_environment(executor)
 
         return flow
 
@@ -368,11 +363,7 @@ class PrefectCloudIntegration:
         job_dict = response.json()
         return job_dict
 
-    def _get_environment(
-        self,
-        cluster_kwargs: Dict[str, Any],
-        adapt_kwargs: Dict[str, Any],
-    ):
+    def _get_environment(self, executor: Optional[DaskExecutor] = None):
         """
         Get an environment that customizes the execution of a Prefect flow run.
         """
@@ -384,11 +375,7 @@ class PrefectCloudIntegration:
         # saturn_flow_id is used by Saturn's custom Prefect agent
         k8s_environment = KubernetesJobEnvironment(
             metadata={"saturn_flow_id": self.flow_id, "image": self.image},
-            executor=DaskExecutor(
-                cluster_class="dask_saturn.SaturnCluster",
-                cluster_kwargs=cluster_kwargs,
-                adapt_kwargs=adapt_kwargs,
-            ),
+            executor=executor,
             job_spec_file=local_tmp_file,
             labels=self._saturn_flow_labels,
             unique_job_name=True,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,6 +18,7 @@ from ruamel.yaml import YAML
 from prefect_saturn._compat import (
     Webhook,
     DaskExecutor,
+    LocalExecutor,
     KUBE_JOB_ENV_AVAILABLE,
     RUN_CONFIG_AVAILABLE,
 )
@@ -353,8 +354,12 @@ def test_get_environment():
         )
         flow = TEST_FLOW.copy()
         integration.register_flow_with_saturn(flow=flow)
-
-        environment = integration._get_environment(cluster_kwargs={"n_workers": 3}, adapt_kwargs={})
+        executor = DaskExecutor(
+            luster_class="dask_saturn.SaturnCluster",
+            cluster_kwargs={"n_workers": 3},
+            adapt_kwargs={},
+        )
+        environment = integration._get_environment(executor)
         assert isinstance(environment, KubernetesJobEnvironment)
         assert environment.unique_job_name is True
         env_args = environment._job_spec["spec"]["template"]["spec"]["containers"][0]["args"]
@@ -398,7 +403,7 @@ def test_executor_dask_kwargs():
 
 
 @responses.activate
-def test_dask_adaptive_scaling_and_autoclosing_off_by_default():
+def test_dask_off_by_default():
     with patch("prefect_saturn.core.Client", new=MockClient):
         responses.add(**REGISTER_FLOW_RESPONSE())
         responses.add(**BUILD_STORAGE_RESPONSE())
@@ -417,9 +422,7 @@ def test_dask_adaptive_scaling_and_autoclosing_off_by_default():
             assert isinstance(flow.environment, KubernetesJobEnvironment)
             executor = flow.environment.executor
 
-        assert isinstance(executor, DaskExecutor)
-        assert executor.cluster_kwargs == {"n_workers": 1, "autoclose": False}
-        assert executor.adapt_kwargs == {}
+        assert isinstance(executor, LocalExecutor)
 
 
 @responses.activate
@@ -454,7 +457,7 @@ def test_get_environment_fails_if_flow_not_registered():
         prefect_cloud_project_name=TEST_PREFECT_PROJECT_NAME
     )
     with raises(RuntimeError, match=prefect_saturn.Errors.NOT_REGISTERED):
-        integration._get_environment(cluster_kwargs={}, adapt_kwargs={})
+        integration._get_environment(LocalExecutor())
 
 
 @responses.activate
@@ -470,7 +473,7 @@ def test_add_environment_fails_if_id_not_recognized():
         integration._set_flow_metadata(flow=flow, instance_size=None)
 
         with raises(HTTPError, match="404 Client Error"):
-            integration._get_environment(cluster_kwargs={}, adapt_kwargs={})
+            integration._get_environment(LocalExecutor())
 
 
 @responses.activate
@@ -520,10 +523,10 @@ def test_register_flow_with_saturn_does_everything():
 
         if RUN_CONFIG_AVAILABLE:
             assert isinstance(flow.run_config, KubernetesRun)
-            assert isinstance(flow.executor, DaskExecutor)
+            assert isinstance(flow.executor, LocalExecutor)
         else:
             assert isinstance(flow.environment, KubernetesJobEnvironment)
-            assert isinstance(flow.environment.executor, DaskExecutor)
+            assert isinstance(flow.environment.executor, LocalExecutor)
 
 
 @responses.activate

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -355,7 +355,7 @@ def test_get_environment():
         flow = TEST_FLOW.copy()
         integration.register_flow_with_saturn(flow=flow)
         executor = DaskExecutor(
-            luster_class="dask_saturn.SaturnCluster",
+            cluster_class="dask_saturn.SaturnCluster",
             cluster_kwargs={"n_workers": 3},
             adapt_kwargs={},
         )


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-saturn! -->

<!--
    Please check a few things before pushing.

    Running `make format` will help your code pass
    `make lint`.
-->

- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

This PR makes prefect-saturn use the LocalExecutor rather than the `DaskExecutor` if no `dask_cluster_kwargs` are passed.

## How does this PR improve `prefect-saturn`?

The default dask cluster behavior was potentially surprising to users. This makes things more explicit.
