### PR TITLE
[ci] update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @jameslamb @dotNomad
+*    @dotNomad


### PR DESCRIPTION
- [x] passes `make lint`
- [x] adds tests to `tests/` (if appropriate)

## What does this PR change?

Removes my username from `CODEOWNERS` for this repo.

## How does this PR improve `prefect-saturn`?

Hi friends! I've been getting email notifications for the last few weeks from this repo's [failing CI job](https://github.com/saturncloud/prefect-saturn/actions/workflows/main.yml). Even turning my "watching" status on the repo all the way down to `Participating and @ mentions` has not stopped those notifications.

So I poked around here and realized I'm still mentioned in the `CODEOWNERS`. Not sure if that will help with the notifications, but either way my user should be removed from that file, and this PR proposes that.

Could you also please check the repo settings, see if I'm still listed as a contributor in the settings, and remove me if I am?

Thanks!
