### PR TITLE
pickle is a bad choice for hashing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ on:
   pull_request:
     branches:
     - main
-  schedule:
+  # schedule:
     # Run every Monday morning at 11:00a UTC, 6:00a CST
-    - cron: '0 11 * * 1'
+    # - cron: '0 11 * * 1'
 
 jobs:
   test:

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -125,7 +125,7 @@ class PrefectCloudIntegration:
             tenant_id,
         ]
         hasher = hashlib.sha256()
-        hasher.update(json.dumps(identifying_content).encode("utf-8"))
+        hasher.update(cloudpickle.dumps(identifying_content, protocol=4))
         return hasher.hexdigest()
 
     def _set_flow_metadata(self, flow: Flow, instance_size: Union[str, None]) -> None:

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -3,12 +3,11 @@ This module contains the user-facing API for ``prefect-saturn``.
 """
 
 import hashlib
-
+import json
 from typing import Any, Dict, List, Optional, Union
 from requests import Session
 from requests.adapters import HTTPAdapter
 
-import cloudpickle
 import prefect
 from prefect import Flow
 from prefect.client import Client
@@ -126,7 +125,7 @@ class PrefectCloudIntegration:
             tenant_id,
         ]
         hasher = hashlib.sha256()
-        hasher.update(cloudpickle.dumps(identifying_content))
+        hasher.update(json.dumps(identifying_content).encode("utf-8"))
         return hasher.hexdigest()
 
     def _set_flow_metadata(self, flow: Flow, instance_size: Union[str, None]) -> None:

--- a/prefect_saturn/core.py
+++ b/prefect_saturn/core.py
@@ -3,12 +3,12 @@ This module contains the user-facing API for ``prefect-saturn``.
 """
 
 import hashlib
-import json
 from typing import Any, Dict, List, Optional, Union
 from requests import Session
 from requests.adapters import HTTPAdapter
 
 import prefect
+import cloudpickle
 from prefect import Flow
 from prefect.client import Client
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ with open("VERSION", "r") as f:
 
 # prefect has to be 0.13.0 or newer to get Webhook storage
 install_requires = [
-    "cloudpickle",
     "dask-saturn>=0.0.4",
     "packaging",
     "prefect>0.13.0",


### PR DESCRIPTION
Without this PR, modifying the python version could lead to different hashes for flow metadata.
This PR hashes identifying information for flows using json, rather than pickle.
This PR *does* change the hashing function. As a result re-registering a flow will create a new flow in Saturn Cloud.
